### PR TITLE
Point links to correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # (re)Gridding with xarray Cookbook
 
-[![nightly-build](https://github.com/ProjectPythia/cookbook-template/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythia/cookbook-template/actions/workflows/nightly-build.yaml)
+[![nightly-build](https://github.com/ProjectPythia/gridding-cookbook/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythia/gridding-cookbook/actions/workflows/nightly-build.yaml)
 [![Binder](http://binder.mypythia.org/badge_logo.svg)](http://binder.mypythia.org/v2/gh/ProjectPythia/gridding-cookbook/main?labpath=notebooks)
 
 This small cookbook will introduce three python packages that grids and re-grids data, that can interface with the xarray ecosystem. This is a common workflow, as modeling (climate, ML, etc.) outputs might not be all on the same scale or same grid. 

--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ sphinx:
     html_permalinks_icon: '<i class="fas fa-link"></i>'
     html_theme_options:
       home_page_in_toc: true
-      repository_url: https://github.com/ProjectPythia/cookbook-template/ # Online location of your book
+      repository_url: https://github.com/ProjectPythia/gridding-cookbook/ # Online location of your book
       repository_branch: main # Which branch of the repository should be used when creating links (optional)
       use_issues_button: true
       use_repository_button: true


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Some URLs in the README and config files were still pointing back to the template repo.

This PR fixes those.

In particular, the nightly build status should now point to the correct test results.